### PR TITLE
增加--no-sourcemap参数用于取消调试

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ module.exports = {
     [ '    --polyfill', 'use core-js to do polyfills' ],
     [ '    --alias', 'path alias' ],
     [ '    --injects', 'inject js into html' ],
+    [ '    --no-sourcemap', 'don\'t use the `SourceMapDevToolPlugin` of plugins to debug' ],
   ],
 
   action: function(options) {
@@ -80,6 +81,7 @@ module.exports = {
     var includes = options.includes;
     var polyfill = !!options.polyfill;
     var host =  options.host;
+    var sourcemap = options.sourcemap;
     var alias = (function(aliasMap) {
       for (var key in aliasMap) {
         aliasMap[key] = util.cwdPath(src, aliasMap[key]);
@@ -121,10 +123,14 @@ module.exports = {
       // plugins
       var plugins = [
         new webpack.NoErrorsPlugin(),
-        new webpack.SourceMapDevToolPlugin({
-          module: false
-        })
       ];
+      if (sourcemap) {
+        plugins.push(
+          new webpack.SourceMapDevToolPlugin({
+            module: false
+          })
+        );
+      }
       vars && plugins.push(new webpack.DefinePlugin(util.parseVars(vars)));
       !lazyload && plugins.push(new webpack.HotModuleReplacementPlugin());
 


### PR DESCRIPTION
```
 new webpack.SourceMapDevToolPlugin({
     module: false
 })
```

nowa-server起服务的时候加入这个插件，导致rebuild速率太慢，本来rebuild只需要1秒,如今一点改动就需要15秒，严重影响开发效率。所以希望加入这个`--no-sourcemap`这个参数，默认为true，还是为调试模式。

当开发页面不需要调试的时候，带入--no-sourcemap参数，使chunks体积减小，提高开发速率